### PR TITLE
limitar caracteres campo endereço

### DIFF
--- a/src/views/sovis/cliente.sql
+++ b/src/views/sovis/cliente.sql
@@ -25,7 +25,7 @@ SELECT
 		0 AS "IDRAMOERP",
 		"CardName"  AS "NOME",
 		"CardName"  AS "RSOCIAL",
-		OCRD."Address"  AS "ENDERECO",
+		LEFT(OCRD."Address",50)  AS "ENDERECO",
 		"Number"  AS "NUMERO",
 		OCRD."Block"  AS "BAIRRO",
 		OCRD."ZipCode"  AS "CEP",


### PR DESCRIPTION
Foi limitado o tamanho do campo endereço da view cliente, pois ultrapassava a quantidade de 50 caracteres