### PR TITLE
Correção Transaction Katrid

### DIFF
--- a/src/transactions/SBO_SP_TransactionNotification_Katrid.sql
+++ b/src/transactions/SBO_SP_TransactionNotification_Katrid.sql
@@ -209,25 +209,32 @@ BEGIN
                 '58'
             );
 
-        -- TRANSFERENCIA DE DEPOSITO
+        -- TRANSFERENCIA DE DEPOSITO  
         ELSEIF (object_type = '67') THEN
-            INSERT INTO "@KATRID_INTE" (
-                "U_Object_Name",
-                "DocEntry",
-                "Object",
-                "RequestStatus",
-                "Remark",
-                "DocNum"
-            )
-            SELECT 
-                'SQLQueries(''Sql_Items'')/List',
-                COALESCE((SELECT MAX("DocEntry") + 1 FROM "@KATRID_INTE"), 1),
-                '''' || TO_VARCHAR("ItemCode") || '''',
-                transaction_type,
-                'item',
-                '67'
-            FROM WTR1
-            WHERE "DocEntry" = list_of_cols_val_tab_del;
+INSERT
+	INTO
+	"@KATRID_INTE" (
+	    "U_Object_Name",
+	    "DocEntry",
+	    "Object",
+	    "RequestStatus",
+	    "Remark",
+	    "DocNum"
+	)
+	SELECT
+	   'SQLQueries(''Sql_Items'')/List', 
+	   COALESCE((SELECT MAX("DocEntry") FROM "@KATRID_INTE"), 1) + ROW_NUMBER() OVER (
+	ORDER BY "ItemCode"),
+	    '''' || TO_VARCHAR("ItemCode") || '''' , 
+	    transaction_type, 
+	    'item', 
+	    '67'
+FROM
+	WTR1
+WHERE
+	"DocEntry" = list_of_cols_val_tab_del
+GROUP BY
+	"ItemCode";
            
 		-- COLABORADORES
         ELSEIF (object_type = '171') THEN


### PR DESCRIPTION
Foi corrigido o script de transferencia de estoque, em que foi substuido a palavra partition por order. Que causava a duplicidade de registro no docentry da trabela @Katrid_Inte