### PR TITLE
Trava de condições de pagamento

### DIFF
--- a/src/transactions/SBO_SP_TransactionNotification_Rovema.sql
+++ b/src/transactions/SBO_SP_TransactionNotification_Rovema.sql
@@ -2653,4 +2653,5 @@ IF :object_type in('23') and  (:transaction_type = 'A' or :transaction_type = 'U
 	END if;
 end if;
 
+
 end;


### PR DESCRIPTION
Foram implementadas duas validações:

Parcelas na Nota Fiscal de Saída
Impede qualquer alteração no número de parcelas da nota fiscal de saída: ele passa a ser automaticamente igual ao definido na condição de pagamento.

Flag “Enviar para Força de Vendas”
Nos documentos de venda, agora é verificado se a condição de pagamento está marcada com a flag Enviar para Força de Vendas. Se essa flag não estiver ativa, o sistema bloqueia o fechamento do pedido ou da nota fiscal.

solicitação feita atraves do chamado
13677