### PR TITLE
Indicador da Natureza do Frete - Nota de Entrada

### DIFF
--- a/src/transactions/SBO_SP_POSTTRANSACTIONNOTICE.sql
+++ b/src/transactions/SBO_SP_POSTTRANSACTIONNOTICE.sql
@@ -68,9 +68,9 @@ END IF;
 
 ----------------------------CAMPOS DE USUARIOS INDICADOR DA NATUREZA DO FRETE-----------------------------------
 IF :object_type = '20' AND (:transaction_type = 'A' OR :transaction_type = 'U') THEN
-		IF EXISTS (	SELECT 1 FROM PCH1 WHERE "CSTfCOFINS" = 50 AND "CSTfPIS" = 50 AND "Usage" = 24 AND "DocEntry" = :list_of_cols_val_tab_del) THEN
-        UPDATE OPCH SET	"U_TX_IndNatFrete" = 9 WHERE OPCH."DocEntry" = :list_of_cols_val_tab_del;
-	END IF;
+IF EXISTS (SELECT 1 FROM PCH1 WHERE "CSTfCOFINS" = 50 AND "CSTfPIS" = 50 AND "Usage" = 24 AND "DocEntry" = :list_of_cols_val_tab_del) THEN
+UPDATE OPCH SET "U_TX_IndNatFrete" = 9 WHERE OPCH."DocEntry" = :list_of_cols_val_tab_del;
+END IF;
 END IF;
 
 --------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Automatização da inserção da informação do indicador da natureza do frete na rotina de nota de entrada.

Conforme chamado aberto no GLPI: https://suporte.gruporovema.com.br/front/ticket.form.php?id=18162